### PR TITLE
Fix Go module path import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module mtlib
+module github.com/vaktibabat/gomt
 
 go 1.22.5


### PR DESCRIPTION
Currently this assumes a namespace that makes it un-importable, this moves the library to match the upstream.

Thanks for the work here, I needed a PHP compatible version for a project and this met the needs best.